### PR TITLE
Fix for GitHub Enterprise.

### DIFF
--- a/octohub/connection.py
+++ b/octohub/connection.py
@@ -38,7 +38,10 @@ class Pager(object):
             if not 'next' in response.parsed_link.keys():
                 break
 
-            self.uri = response.parsed_link.next.uri
+            # Parsed link is absolute. Connection wants a relative link,
+            # so remove protocol and GitHub endpoint for the pagination URI.
+            m = re.match(self.conn.endpoint + '(.*)', response.parsed_link.next.uri)
+            self.uri = m.groups()[0]
             self.params = response.parsed_link.next.params
 
 class Connection(object):

--- a/octohub/response.py
+++ b/octohub/response.py
@@ -30,7 +30,7 @@ def _parse_link(header_link):
     for s in header_link.split(','):
         link = AttrDict()
 
-        m = re.match('<https://api.github.com(.*)\?(.*)>', s.split(';')[0].strip())
+        m = re.match('<(.*)\?(.*)>', s.split(';')[0].strip())
         link.uri = m.groups()[0]
         link.params = {}
         for kv in m.groups()[1].split('&'):


### PR DESCRIPTION
Remove hardcoded hostname api.github.com from pagination links. This
fixes pagination for self-hosted GitHub Enterprise.