### PR TITLE
Add support for beta API features: --enable-preview

### DIFF
--- a/octohub/connection.py
+++ b/octohub/connection.py
@@ -45,12 +45,14 @@ class Pager(object):
             self.params = response.parsed_link.next.params
 
 class Connection(object):
-    def __init__(self, token=None):
+    def __init__(self, token=None, headers=None):
         """OctoHub connection
             token (str): GitHub Token (anonymous if not provided)
         """
         self.endpoint = 'https://api.github.com'
         self.headers = {'User-Agent': __useragent__}
+        if headers:
+            self.headers.update(headers)
 
         if token:
             self.headers['Authorization'] = 'token %s' % token


### PR DESCRIPTION
As mentioned in the Github API doc, some API features are only available
when passing a specific Accept: HTTP header.

See e.g. the blocking API, currently in beta:
 https://developer.github.com/v3/users/blocking/

I've added an option in the Connection constructor to pass custom headers (might prove useful in other cases in the future), and a CLI parameter to pass that specific header.