### PR TITLE
Bullseye bugfixing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ OctoHub: Low level Python and CLI interface to GitHub
 =====================================================
 
 OctoHub is a Python package that provides a low level interface to the
-full GitHub v3 API:
+full GitHub REST API:
 
 * `Activity`_
 * `Gists`_
@@ -32,11 +32,23 @@ love pull requests, see our `gitflow`_ for guidelines and walk through.
 Installation
 ------------
 
+On TurnKey Linux (v17+)::
+
+    # as root
+    apt update
+    apt install octohub
+
+On Debian (11/Buster+)::
+
+    # check http://archive.turnkeylinux.org/debian/pool/bullseye/main/o/octohub/ for latest version
+    $ wget http://archive.turnkeylinux.org/debian/pool/bullseye/main/o/octohub/octohub_#VERSION#_amd64.deb
+    $ sudo apt install ./octohub_#VERSION#_amd64.deb
+
 ::
 
     $ git clone https://github.com/turnkeylinux/octohub.git
     $ cd octohub
-    $ sudo make install
+    $ sudo python3 setup.py install
 
 Dependencies
 ''''''''''''
@@ -47,8 +59,8 @@ GitHub Token
 ------------
 
 OctoHub can be used anonymously, but is much more useful when authenticated.
-You can create a revokable access token under ``Personal API Tokens`` in your
-`account settings`_.
+You can create a revokable access token under `Personal access tokens`_ in your
+`Account settings`_.
 
 Usage examples (API)
 --------------------
@@ -75,8 +87,9 @@ Usage examples (CLI)
 ::
 
     # A Personal Access Token from your GitHub account:
-    #   Account Settings > Applications > Personal Access Tokens > Create new token
-    $ export OCTOHUB_TOKEN=d34db33fd34db33fd34db33fd34db33fd34db33f
+    #   Account Settings > Developer settings > Personal access tokens > Generate new token
+
+    $ export OCTOHUB_TOKEN=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
     $ export OCTOHUB_LOGLEVEL=INFO
     $ octohub GET /repos/turnkeylinux/tracker/issues labels=feature,core per_page=100
 
@@ -108,18 +121,18 @@ For more example usage::
     $ octohub --help
 
 
-.. _Activity: http://developer.github.com/v3/activity/
-.. _Gists: http://developer.github.com/v3/gists/
-.. _Git Data: http://developer.github.com/v3/git/
-.. _Issues: http://developer.github.com/v3/issues/
-.. _Orgs: http://developer.github.com/v3/orgs/
-.. _Pull Requests: http://developer.github.com/v3/pulls/
-.. _Repositories: http://developer.github.com/v3/repos/
-.. _Users: http://developer.github.com/v3/users/
-.. _Search: http://developer.github.com/v3/search/
-.. _online documentation: http://developer.github.com/v3/
+.. _Activity: https://docs.github.com/en/rest/reference/activity
+.. _Gists: https://docs.github.com/en/rest/reference/gists
+.. _Git Data: https://docs.github.com/en/rest/reference/git
+.. _Issues: https://docs.github.com/en/rest/reference/issues
+.. _Orgs: https://docs.github.com/en/rest/reference/orgs
+.. _Pull Requests: https://docs.github.com/en/rest/reference/pulls
+.. _Repositories: https://docs.github.com/en/rest/reference/repos
+.. _Users: https://docs.github.com/en/rest/reference/users
+.. _Search: https://docs.github.com/en/rest/reference/search
+.. _online documentation: https://docs.github.com/en/rest
 .. _contrib: https://github.com/turnkeylinux/octohub/tree/master/contrib/
 .. _gitflow: https://github.com/turnkeylinux/tracker/blob/master/GITFLOW.rst
-.. _python-requests: http://python-requests.org/
-.. _account settings: https://github.com/settings/applications
-
+.. _python-requests: https://docs.python-requests.org/en/latest/
+.. _Account settings: https://github.com/settings
+.. _Personal access token: https://github.com/settings/tokens

--- a/debian/control
+++ b/debian/control
@@ -21,4 +21,5 @@ Depends:
  python3-requests,
 Suggests:
  python3-profiler,
+ jq,
 Description: OctoHub: Low level Python and CLI interface to GitHub

--- a/octohub/utils.py
+++ b/octohub/utils.py
@@ -13,12 +13,6 @@ from typing import Any, Optional, Protocol
 
 from requests import Response
 
-class ResponseExt(Protocol):
-    parsed: AttrDict
-    parsed_link: AttrDict
-
-class OctoResponse(Response, ResponseExt):
-    ...
 
 class AttrDict(dict):
     """Attribute Dictionary (set and access attributes 'pythonically')"""
@@ -29,6 +23,15 @@ class AttrDict(dict):
 
     def __setattr__(self, name: str, val: Any):
         self[name] = val
+
+
+class ResponseExt(Protocol):
+    parsed: AttrDict
+    parsed_link: AttrDict
+
+
+class OctoResponse(Response, ResponseExt):
+    ...
 
 
 def get_logger(name: str, level: Optional[str]=None) -> logging.Logger:


### PR DESCRIPTION
I just installed the shiny new Octohub (v0.4 - installed from the TurnKey Bullseye repo) into a v17.0rc1 TKLDev and to my dismay it doesn't work?!

Here's what happened:
```
Traceback (most recent call last):
  File "/usr/bin/octohub", line 45, in <module>
    from octohub.connection import Connection, Pager
  File "/usr/lib/python3.9/dist-packages/octohub/connection.py", line 15, in <module>
    from octohub.response import parse_response
  File "/usr/lib/python3.9/dist-packages/octohub/response.py", line 13, in <module>
    from octohub.utils import AttrDict, OctoResponse, get_logger
  File "/usr/lib/python3.9/dist-packages/octohub/utils.py", line 16, in <module>
    class ResponseExt(Protocol):
  File "/usr/lib/python3.9/dist-packages/octohub/utils.py", line 17, in ResponseExt
    parsed: AttrDict
NameError: name 'AttrDict' is not defined
```
I moved things around a bit in `octohub/utils.py` (see https://github.com/turnkeylinux/octohub/commit/6fd2397a4fa3e4a0dd0ac677138abe81074b3289) and then got this:
```
Traceback (most recent call last):
  File "/usr/bin/octohub", line 45, in <module>
    from octohub.connection import Connection, Pager
  File "/usr/lib/python3.9/dist-packages/octohub/connection.py", line 19, in <module>
    class Pager:
  File "/usr/lib/python3.9/dist-packages/octohub/connection.py", line 20, in Pager
    def __init__(self, conn: Connection, uri: str, params: dict, max_pages: int=0):
NameError: name 'Connection' is not defined
```
I did a similar bit of rearrangement in `octohub/connection.py` (see https://github.com/turnkeylinux/octohub/commit/1642b25ebec582d08419be7ef49b0ac0c538b625). That seemed to fix the immediate issues, but there may be more...

Closes https://github.com/turnkeylinux/tracker/issues/1682